### PR TITLE
Always use alloc crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ x25519-dalek = "0.5"
 
 [features]
 default = ["std"]
-nightly = []
 std = []
 # Allow doctests with mock objects
 # See: https://github.com/rust-lang/rust/issues/45599

--- a/README.md
+++ b/README.md
@@ -87,10 +87,7 @@ by adding the following to your `Cargo.toml`:
 double-ratchet = "0.1"
 ```
 
-The `std` feature is enabled by default. To remove the dependency on the
-standard library requires nightly because of dependency on the [`alloc`
-crate](https://doc.rust-lang.org/alloc/): compile with `--no-default-features
---features "nightly"`.
+The `std` feature is enabled by default. If you don't want to use `std`, compile with `--no-default-features`.
 
 
 ## Documentation

--- a/src/dr.rs
+++ b/src/dr.rs
@@ -5,10 +5,7 @@ use rand_core::{CryptoRng, RngCore};
 #[cfg(feature = "std")]
 use std::error::Error;
 
-#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-#[cfg(feature = "std")]
-use std::vec::Vec;
 
 // TODO: avoid heap allocations in encrypt/decrypt interfaces
 // TODO: make stuff like MAX_SKIP and MKS_CAPACITY dynamic

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,9 @@
 // TODO: test examples in README.md
 
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(alloc))]
 #![warn(clippy::pedantic)]
 #![warn(missing_docs)]
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Crate documentation provided in README.md
 
-// TODO: include README.md documentation
+// TODO: include README.md documentation: https://github.com/rust-lang/rust/issues/44732
 // TODO: test examples in README.md
 
 #![no_std]


### PR DESCRIPTION
This is a small refactor enabled by the alloc crate having become stable [in Rust 1.36.0](https://github.com/rust-lang/rust/blob/1.36.0/RELEASES.md#version-1360-2019-07-04)